### PR TITLE
Fix invalid include paths.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"extra": {
 		"phpstan": {
 			"includes": [
-				"rules.neon"
+				"extension.neon"
 			]
 		}
 	},


### PR DESCRIPTION
Include extension.neon instead of rules.neon which does not exists

Currently when using phpstan/extension-installer with this extension, the installation process fails silently because it cannot find the "rules.neon" specified in composer.json
So when you run vendor/bin/phpstan, phpstan fails to run immediately and outputs the following message:
"Config file $PWD/vendor/killov/phpstan-banned-double-equals/rules.neon does not exist or isn't readable"

Tested fix locally, seems to fix the issue :slightly_smiling_face: 